### PR TITLE
Fix compiler alignment warning of LCII_pcounters_per_thread_t

### DIFF
--- a/src/profile/performance_counter.c
+++ b/src/profile/performance_counter.c
@@ -1,6 +1,7 @@
 #include "runtime/lcii.h"
 
-LCII_pcounters_per_thread_t LCII_pcounters[LCI_PCOUNTER_MAX_NTHREADS];
+LCII_pcounters_per_thread_t LCII_pcounters[LCI_PCOUNTER_MAX_NTHREADS]
+    __attribute__((aligned(LCI_CACHE_LINE)));
 
 void LCII_pcounters_init()
 {

--- a/src/profile/performance_counter.h
+++ b/src/profile/performance_counter.h
@@ -7,7 +7,7 @@
 #define LCII_PCOUNTERS_WRAPPER(stat)
 #endif
 
-typedef struct __attribute__((aligned(LCI_CACHE_LINE))) {
+typedef struct {
   int64_t msgs_tx;
   int64_t bytes_tx;
   int64_t msgs_rx;


### PR DESCRIPTION
Move __attribute__((aligned(LCI_CACHE_LINE))) to LCII_pcounters variable definition.

So we can fix the "note: the ABI for passing parameters with 64-byte alignment has changed in GCC 4.6" warning.