### PR TITLE
Make LCI_SERVER a hint instead of a requirement.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,6 @@ jobs:
                 -B /lci/build \
                 -GNinja \
                 -DCMAKE_BUILD_TYPE=Release \
-                -DLCI_SERVER=ofi \
                 -DLCI_DEBUG=OFF
       - persist_to_workspace:
           root: /lci

--- a/.github/workflows/ctest-debug.yml
+++ b/.github/workflows/ctest-debug.yml
@@ -31,7 +31,6 @@ jobs:
                 -Bbuild \
                 -GNinja \
                 -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
-                -DLCI_SERVER=ofi \
                 -DLCI_DEBUG=ON \
                 -DSRUN_EXTRA_ARG="--oversubscribe" \
                 .

--- a/.github/workflows/ctest-release.yml
+++ b/.github/workflows/ctest-release.yml
@@ -31,7 +31,6 @@ jobs:
                 -Bbuild \
                 -GNinja \
                 -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
-                -DLCI_SERVER=ofi \
                 -DLCI_DEBUG=OFF \
                 -DSRUN_EXTRA_ARG="--oversubscribe" \
                 .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ option(LCI_WITH_BENCHMARKS "Build LCI benchmarks" ON)
 option(LCI_WITH_DOC "Build LCI documentation" ON)
 
 set(LCI_SERVER
-    ofi
+    ibv
     CACHE STRING "Fabric")
 set_property(CACHE LCI_SERVER PROPERTY STRINGS ofi ibv)
 option(LCI_DEBUG "LCI Debug Mode" OFF)
@@ -81,14 +81,6 @@ include(CMakePackageConfigHelpers)
 include(TargetSourcesRelative)
 include(AddLCI)
 
-if(LCI_SERVER STREQUAL "ofi")
-  set(LCI_USE_SERVER_OFI ON)
-elseif(LCI_SERVER STREQUAL "ibv")
-  set(LCI_USE_SERVER_IBV ON)
-else()
-  message(FATAL_ERROR "Fabric ${LCI_SERVER} not supported")
-endif()
-
 if("sync" IN_LIST LCI_EP_CE)
   set(LCI_SERVER_HAS_SYNC ON)
 endif()
@@ -102,12 +94,32 @@ if("glob" IN_LIST LCI_EP_CE)
   set(LCI_SERVER_HAS_GLOB ON)
 endif()
 
-# find package set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
-# set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads REQUIRED)
 
-string(TOUPPER ${LCI_SERVER} FABRIC)
-find_package(${FABRIC} REQUIRED)
+# Figure out which network backend to use
+find_package(OFI)
+find_package(IBV)
+if(IBV_FOUND AND OFI_FOUND)
+  if(LCI_SERVER STREQUAL "ofi")
+    set(FABRIC OFI)
+  else()
+    set(FABRIC IBV)
+  endif()
+elseif(IBV_FOUND)
+  set(FABRIC IBV)
+elseif(OFI_FOUND)
+  set(FABRIC OFI)
+else()
+  message(FATAL_ERROR "Find neither libfabric nor libibverbs. Give up!")
+endif()
+
+if(FABRIC STREQUAL OFI)
+  set(LCI_USE_SERVER_OFI ON)
+  message("Use ofi(libfabric) as the network backend")
+else()
+  set(LCI_USE_SERVER_IBV ON)
+  message("Use ibv(libibverbs) as the network backend")
+endif()
 
 find_package(PAPI)
 option(LCI_USE_PAPI "Use PAPI to collect hardware counters" ${PAPI_FOUND})
@@ -130,7 +142,7 @@ if(LCI_OPTIMIZE_FOR_NATIVE)
   endif()
 endif()
 
-add_library(LCI src/runtime/rcache/lcii_rcache.h)
+add_library(LCI)
 set_target_properties(
   LCI
   PROPERTIES C_VISIBILITY_PRESET hidden

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ make install
 ### Important CMake variables
 - `CMAKE_INSTALL_PREFIX=/path/to/install`: Where to install LCI
   - This is the same across all the cmake projects.
-- `LCI_SERVER=ibv/ofi`: The network backend to use.
+- `LCI_SERVER=ibv/ofi`: Hint to which network backend to use. If both `ibv` and `ofi` are found, LCI will use the one
+indicated by this variable. The default value is `ibv`.
   - ibv: libibverbs, typically for infiniband.
   - ofi: libfabrics, for all other networks (slingshot-11, ethernet, shared memory).
 - `LCI_PM_BACKEND_DEFAULT=pmi1/pmi2/pmix/mpi`: The default PMI backend to use.


### PR DESCRIPTION
LCI will try to find both `ibv` and `ofi`. If both are found, it will use the one indicated by `LCI_SERVER`. Otherwise, it will just use whatever is found.

I set the default value to `ibv` because, typically, if `libibverbs` presents, it is the preferred backend.