### PR TITLE
Improve PMI backend selection.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,13 @@ make install
 ### Important CMake variables
 - `CMAKE_INSTALL_PREFIX=/path/to/install`: Where to install LCI
   - This is the same across all the cmake projects.
-- `LCI_SERVER=ibv/ofi`: Hint to which network backend to use. If both `ibv` and `ofi` are found, LCI will use the one
-indicated by this variable. The default value is `ibv`.
-  - ibv: libibverbs, typically for infiniband.
-  - ofi: libfabrics, for all other networks (slingshot-11, ethernet, shared memory).
-- `LCI_PM_BACKEND_DEFAULT=pmi1/pmi2/pmix/mpi`: The default PMI backend to use.
-  - Refer to [Choose the right PMI backend](#choose-the-right-pmi-backend) 
-    for which backend you should use.
 - `LCI_DEBUG=ON/OFF`: Enable/disable the debug mode (more assertions and log).
+  The default value is `OFF`.
+- `LCI_SERVER=ibv/ofi`: Hint to which network backend to use. If both `ibv` and `ofi` are found, LCI will use the one
+  indicated by this variable. The default value is `ibv`. Typically, you don't need to
+  modify this variable as if `libibverbs` presents, it is likely to be the recommended one to use.
+  - `ibv`: libibverbs, typically for infiniband.
+  - `ofi`: libfabrics, for all other networks (slingshot-11, ethernet, shared memory).
 
 ## Run LCI applications
 
@@ -39,36 +38,6 @@ or
 ```
 srun -n 2 ./hello_world
 ```
-
-### Choose the right PMI backend
-Choosing the right PMI backend to use is important. LCI offers four PMI backends: pmi1,
-pmi2, pmix, and mpi. You can use `LCI_PM_BACKEND_DEFAULT` to specify the default
-backend when running `cmake`, or the environment variable `LCI_PM_BACKEND` to specify
-the backend when executing the program.
-
-An easy way to decide the right PMI backend is to run
-```
-mpirun -n 1 env | grep PMI
-```
-if you are using `mpirun`, or
-```
-srun -n 1 env | grep PMI
-```
-if you are using `srun`. If you see `PMI_RANK` in the output, you should use either pmi1
-or pmi2. If you see `PMIX_RANK` in the output, you should use pmix.
-
-If you are using `srun` but can see neither `PMI_RANK` nor `PMIX_RANK`, you should try
-the `--mpi` arguments of `srun`. For example,
-```
-srun --mpi=pmi2 -n 1 ./application
-```
-should set up a pmi2 environment.
-```
-srun --mpi=pmix -n 1 ./application
-```
-should set up a pmix environment.
-
-As a last resort, you can always use the `mpi` backend.
 
 ## Write a LCI program
 

--- a/doc/details/pmi_backend.md
+++ b/doc/details/pmi_backend.md
@@ -1,0 +1,35 @@
+# Choose the right PMI backend
+Choosing the right PMI backend used to be important. However, after the upgrade of 
+cmake variable `LCM_PM_BACKEND_DEFAULT` and environment variable `LCI_PM_BACKEND` into a list
+of options for LCI to try. The default value can handle most of the cases so users don't need
+to care too much about it anymore. Nevertheless, we keep the old documents here in case users
+want to manually decide which PMI backend to use.
+
+LCI offers five PMI backends: pmi1,
+pmi2, pmix, mpi, and local. You can use `LCI_PM_BACKEND_DEFAULT` to specify the default
+backend when running `cmake`, or the environment variable `LCI_PM_BACKEND` to specify
+the backend when executing the program.
+
+An easy way to decide the right PMI backend is to run
+```
+mpirun -n 1 env | grep PMI
+```
+if you are using `mpirun`, or
+```
+srun -n 1 env | grep PMI
+```
+if you are using `srun`. If you see `PMI_RANK` in the output, you should use either pmi1
+or pmi2. If you see `PMIX_RANK` in the output, you should use pmix.
+
+If you are using `srun` but can see neither `PMI_RANK` nor `PMIX_RANK`, you should try
+the `--mpi` arguments of `srun`. For example,
+```
+srun --mpi=pmi2 -n 1 ./application
+```
+should set up a pmi2 environment.
+```
+srun --mpi=pmix -n 1 ./application
+```
+should set up a pmix environment.
+
+As a last resort, you can always use the `mpi` backend.

--- a/src/pmi/CMakeLists.txt
+++ b/src/pmi/CMakeLists.txt
@@ -1,11 +1,15 @@
 set(LCI_PM_BACKEND_DEFAULT
-    pmi2
-    CACHE STRING "Process management backend to use")
-set_property(CACHE LCI_PM_BACKEND_DEFAULT PROPERTY STRINGS pmi1 pmi2 pmix mpi)
+    "pmix;pmi2;pmi1;mpi;local"
+    CACHE
+      STRING
+      "A list of process management backend with comma/space/semicolon as delimitors.
+      LCI will try each entry one by one until it found an available backend to use
+      (available entries: pmi1, pmi2, pmix, mpi, local)")
 
 set(LIBRARY_NAME LCI)
-target_sources_relative(${LIBRARY_NAME} PRIVATE pmi_wrapper.c
-                        pmi_wrapper_pmi1.c pmi_wrapper_pmi2.c)
+target_sources_relative(
+  ${LIBRARY_NAME} PRIVATE pmi_wrapper.c pmi_wrapper_pmi1.c pmi_wrapper_pmi2.c
+  pmi_wrapper_local.c)
 add_subdirectory(pmi1)
 add_subdirectory(pmi2)
 
@@ -17,9 +21,6 @@ if(MPI_FOUND)
   target_sources_relative(${LIBRARY_NAME} PRIVATE pmi_wrapper_mpi.c)
   cmake_policy(SET CMP0079 NEW)
   target_link_libraries(${LIBRARY_NAME} PRIVATE MPI::MPI_C)
-elseif(LCI_PM_BACKEND_DEFAULT STREQUAL "mpi")
-  message(
-    FATAL_ERROR "LCI_PM_BACKEND_DEFAULT is set to MPI but MPI is not found.")
 endif()
 
 find_package(PMIx COMPONENTS C)
@@ -30,9 +31,6 @@ if(PMIX_FOUND)
   target_sources_relative(${LIBRARY_NAME} PRIVATE pmi_wrapper_pmix.c)
   cmake_policy(SET CMP0079 NEW)
   target_link_libraries(${LIBRARY_NAME} PRIVATE PMIx::PMIx)
-elseif(LCI_PM_BACKEND_DEFAULT STREQUAL "pmix")
-  message(
-    FATAL_ERROR "LCI_PM_BACKEND_DEFAULT is set to PMIx but PMIx is not found.")
 endif()
 
 target_include_directories(${LIBRARY_NAME} PRIVATE .)

--- a/src/pmi/pmi_wrapper.h
+++ b/src/pmi/pmi_wrapper.h
@@ -19,6 +19,7 @@ void lcm_pm_barrier();
 void lcm_pm_finalize();
 
 struct LCM_PM_ops_t {
+  int (*check_availability)();
   void (*initialize)();
   int (*is_initialized)();
   int (*get_rank)();
@@ -28,6 +29,8 @@ struct LCM_PM_ops_t {
   void (*barrier)();
   void (*finalize)();
 };
+
+void lcm_pm_local_setup_ops(struct LCM_PM_ops_t* ops);
 
 void lcm_pm_pmi1_setup_ops(struct LCM_PM_ops_t* ops);
 

--- a/src/pmi/pmi_wrapper_local.c
+++ b/src/pmi/pmi_wrapper_local.c
@@ -1,0 +1,53 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include "pmi_wrapper.h"
+#include "pmii_archive.h"
+
+static int initialized = 0;
+static Archive_t l_archive;
+
+int lcm_pm_local_check_availability() { return true; }
+
+void lcm_pm_local_initialize()
+{
+  archive_init(&l_archive);
+  initialized = 1;
+}
+
+int lcm_pm_local_initialized() { return initialized; }
+int lcm_pm_local_get_rank() { return 0; }
+
+int lcm_pm_local_get_size() { return 1; }
+
+void lcm_pm_local_publish(char* key, char* value)
+{
+  archive_push(&l_archive, key, value);
+}
+
+void lcm_pm_local_getname(int rank, char* key, char* value)
+{
+  char* ret = archive_search(&l_archive, key);
+  strcpy(value, ret);
+}
+
+void lcm_pm_local_barrier() {}
+
+void lcm_pm_local_finalize()
+{
+  archive_fina(&l_archive);
+  initialized = 0;
+}
+
+void lcm_pm_local_setup_ops(struct LCM_PM_ops_t* ops)
+{
+  ops->check_availability = lcm_pm_local_check_availability;
+  ops->initialize = lcm_pm_local_initialize;
+  ops->is_initialized = lcm_pm_local_initialized;
+  ops->get_rank = lcm_pm_local_get_rank;
+  ops->get_size = lcm_pm_local_get_size;
+  ops->publish = lcm_pm_local_publish;
+  ops->getname = lcm_pm_local_getname;
+  ops->barrier = lcm_pm_local_barrier;
+  ops->finalize = lcm_pm_local_finalize;
+}

--- a/src/pmi/pmi_wrapper_mpi.c
+++ b/src/pmi/pmi_wrapper_mpi.c
@@ -2,92 +2,14 @@
 #include <stdio.h>
 #include <string.h>
 #include "pmi_wrapper.h"
+#include "pmii_archive.h"
 #include <mpi.h>
 
-typedef struct Entry_t {
-  char* key;
-  char* value;
-} Entry_t;
-
-typedef struct Archive_t {
-  Entry_t* ptr;
-  int size;
-  int capacity;
-} Archive_t;
 static int initialized = 0;
 static int to_finalize_mpi = 0;
-Archive_t l_archive, g_archive;
-const int STRING_LIMIT = 256;
+static Archive_t l_archive, g_archive;
 
-void archive_init(Archive_t* archive)
-{
-  archive->capacity = 8;
-  archive->size = 0;
-  archive->ptr = malloc(archive->capacity * sizeof(struct Entry_t));
-  if (archive->ptr == NULL) {
-    fprintf(stderr, "Cannot get more memory for archive of capacity %d",
-            archive->capacity);
-    exit(1);
-  }
-}
-
-void archive_fina(Archive_t* archive)
-{
-  if (archive->ptr != NULL) {
-    for (int i = 0; i < archive->size; ++i) {
-      free(archive->ptr[i].key);
-      archive->ptr[i].key = NULL;
-      free(archive->ptr[i].value);
-      archive->ptr[i].value = NULL;
-    }
-    free(archive->ptr);
-    archive->ptr = NULL;
-  }
-  archive->size = 0;
-  archive->capacity = 0;
-}
-
-void archive_clear(Archive_t* archive)
-{
-  for (int i = 0; i < archive->size; ++i) {
-    free(archive->ptr[i].key);
-    archive->ptr[i].key = NULL;
-    free(archive->ptr[i].value);
-    archive->ptr[i].value = NULL;
-  }
-  archive->size = 0;
-}
-
-void archive_push(Archive_t* archive, char* key, char* value)
-{
-  if (archive->size == archive->capacity) {
-    archive->capacity *= 2;
-    archive->ptr =
-        realloc(archive->ptr, archive->capacity * sizeof(struct Entry_t));
-    if (archive->ptr == NULL) {
-      fprintf(stderr, "Cannot get more memory for archive of capacity %d",
-              archive->capacity);
-      exit(1);
-    }
-  }
-  char* key_in = malloc(STRING_LIMIT);
-  strcpy(key_in, key);
-  char* value_in = malloc(STRING_LIMIT);
-  strcpy(value_in, value);
-  archive->ptr[archive->size].key = key_in;
-  archive->ptr[archive->size].value = value_in;
-  ++archive->size;
-}
-
-char* archive_search(Archive_t* archive, char* key)
-{
-  for (int i = 0; i < archive->size; ++i) {
-    if (strcmp(archive->ptr[i].key, key) == 0) {
-      return archive->ptr[i].value;
-    }
-  }
-  return NULL;
-}
+int lcm_pm_mpi_check_availability() { return true; }
 
 void lcm_pm_mpi_initialize()
 {
@@ -192,6 +114,7 @@ void lcm_pm_mpi_finalize()
 
 void lcm_pm_mpi_setup_ops(struct LCM_PM_ops_t* ops)
 {
+  ops->check_availability = lcm_pm_mpi_check_availability;
   ops->initialize = lcm_pm_mpi_initialize;
   ops->is_initialized = lcm_pm_mpi_initialized;
   ops->get_rank = lcm_pm_mpi_get_rank;

--- a/src/pmi/pmi_wrapper_pmi1.c
+++ b/src/pmi/pmi_wrapper_pmi1.c
@@ -3,6 +3,15 @@
 #include "pmi_wrapper.h"
 #include "pmi.h"
 
+int lcm_pm_pmi1_check_availability()
+{
+  char* p = getenv("PMI_RANK");
+  if (p)
+    return true;
+  else
+    return false;
+}
+
 void lcm_pm_pmi1_initialize()
 {
   int spawned, rank_me, nranks;
@@ -49,6 +58,7 @@ void lcm_pm_pmi1_finalize() { PMI_Finalize(); }
 
 void lcm_pm_pmi1_setup_ops(struct LCM_PM_ops_t* ops)
 {
+  ops->check_availability = lcm_pm_pmi1_check_availability;
   ops->initialize = lcm_pm_pmi1_initialize;
   ops->is_initialized = lcm_pm_pmi1_initialized;
   ops->get_rank = lcm_pm_pmi1_get_rank;

--- a/src/pmi/pmi_wrapper_pmi2.c
+++ b/src/pmi/pmi_wrapper_pmi2.c
@@ -3,6 +3,15 @@
 #include "pmi_wrapper.h"
 #include "pmi2.h"
 
+int lcm_pm_pmi2_check_availability()
+{
+  char* p = getenv("PMI_RANK");
+  if (p)
+    return true;
+  else
+    return false;
+}
+
 void lcm_pm_pmi2_initialize()
 {
   int spawned, appnum, rank, size;
@@ -43,6 +52,7 @@ void lcm_pm_pmi2_finalize() { PMI2_Finalize(); }
 
 void lcm_pm_pmi2_setup_ops(struct LCM_PM_ops_t* ops)
 {
+  ops->check_availability = lcm_pm_pmi2_check_availability;
   ops->initialize = lcm_pm_pmi2_initialize;
   ops->is_initialized = lcm_pm_pmi2_initialized;
   ops->get_rank = lcm_pm_pmi2_get_rank;

--- a/src/pmi/pmi_wrapper_pmix.c
+++ b/src/pmi/pmi_wrapper_pmix.c
@@ -19,6 +19,15 @@
 pmix_proc_t proc_me;
 pmix_proc_t proc_wild;
 
+int lcm_pm_pmix_check_availability()
+{
+  char* p = getenv("PMIX_RANK");
+  if (p)
+    return true;
+  else
+    return false;
+}
+
 void lcm_pm_pmix_initialize()
 {
   PMIX_SAFECALL(PMIx_Init(&proc_me, NULL, 0));
@@ -78,6 +87,7 @@ void lcm_pm_pmix_finalize() { PMIX_SAFECALL(PMIx_Finalize(NULL, 0)); }
 
 void lcm_pm_pmix_setup_ops(struct LCM_PM_ops_t* ops)
 {
+  ops->check_availability = lcm_pm_pmix_check_availability;
   ops->initialize = lcm_pm_pmix_initialize;
   ops->is_initialized = lcm_pm_pmix_initialized;
   ops->get_rank = lcm_pm_pmix_get_rank;

--- a/src/pmi/pmii_archive.h
+++ b/src/pmi/pmii_archive.h
@@ -1,0 +1,90 @@
+#ifndef LCI_PMII_ARCHIVE_H
+#define LCI_PMII_ARCHIVE_H
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+typedef struct Entry_t {
+  char* key;
+  char* value;
+} Entry_t;
+
+typedef struct Archive_t {
+  Entry_t* ptr;
+  int size;
+  int capacity;
+} Archive_t;
+
+static const int STRING_LIMIT = 256;
+
+static void archive_init(Archive_t* archive)
+{
+  archive->capacity = 8;
+  archive->size = 0;
+  archive->ptr = malloc(archive->capacity * sizeof(struct Entry_t));
+  if (archive->ptr == NULL) {
+    fprintf(stderr, "Cannot get more memory for archive of capacity %d",
+            archive->capacity);
+    exit(1);
+  }
+}
+
+static void archive_fina(Archive_t* archive)
+{
+  if (archive->ptr != NULL) {
+    for (int i = 0; i < archive->size; ++i) {
+      free(archive->ptr[i].key);
+      archive->ptr[i].key = NULL;
+      free(archive->ptr[i].value);
+      archive->ptr[i].value = NULL;
+    }
+    free(archive->ptr);
+    archive->ptr = NULL;
+  }
+  archive->size = 0;
+  archive->capacity = 0;
+}
+
+static void archive_clear(Archive_t* archive)
+{
+  for (int i = 0; i < archive->size; ++i) {
+    free(archive->ptr[i].key);
+    archive->ptr[i].key = NULL;
+    free(archive->ptr[i].value);
+    archive->ptr[i].value = NULL;
+  }
+  archive->size = 0;
+}
+
+static void archive_push(Archive_t* archive, char* key, char* value)
+{
+  if (archive->size == archive->capacity) {
+    archive->capacity *= 2;
+    archive->ptr =
+        realloc(archive->ptr, archive->capacity * sizeof(struct Entry_t));
+    if (archive->ptr == NULL) {
+      fprintf(stderr, "Cannot get more memory for archive of capacity %d",
+              archive->capacity);
+      exit(1);
+    }
+  }
+  char* key_in = malloc(STRING_LIMIT);
+  strcpy(key_in, key);
+  char* value_in = malloc(STRING_LIMIT);
+  strcpy(value_in, value);
+  archive->ptr[archive->size].key = key_in;
+  archive->ptr[archive->size].value = value_in;
+  ++archive->size;
+}
+
+static char* archive_search(Archive_t* archive, char* key)
+{
+  for (int i = 0; i < archive->size; ++i) {
+    if (strcmp(archive->ptr[i].key, key) == 0) {
+      return archive->ptr[i].value;
+    }
+  }
+  return NULL;
+}
+
+#endif  // LCI_PMII_ARCHIVE_H


### PR DESCRIPTION
This PR enables `LCI_PM_BACKEND_DEFAULT` and `LCI_PM_BACKEND` to accept a list of potential PMI backends. The runtime will try each entry one by one until it finds one available to use. By setting the default value to  `pmix;pmi2;pmi1;mpi;local`, users don't need to select the PMI backend manually in most of cases.

Also add a new PMI backend: local, which just sets the rank to 0 and process size to 1.