### PR TITLE
Enable debug build for detecting double free of packets.

### DIFF
--- a/src/runtime/1sided_primitive.c
+++ b/src/runtime/1sided_primitive.c
@@ -56,7 +56,7 @@ LCI_error_t LCI_putma(LCI_endpoint_t ep, LCI_mbuffer_t buffer, int rank,
                           buffer.address, buffer.length,
                           LCII_MAKE_PROTO(ep->gid, LCI_MSG_RDMA_MEDIUM, tag));
   } else {
-    LCII_packet_t* packet = LCII_pool_get_nb(ep->pkpool);
+    LCII_packet_t* packet = LCII_alloc_packet_nb(ep->pkpool);
     if (packet == NULL) {
       // no packet is available
       LCII_PCOUNTERS_WRAPPER(
@@ -157,7 +157,7 @@ LCI_error_t LCI_putla(LCI_endpoint_t ep, LCI_lbuffer_t buffer,
         LCII_pcounters[LCIU_get_thread_id()].send_lci_failed_bq++);
     return LCI_ERR_RETRY;
   }
-  LCII_packet_t* packet = LCII_pool_get_nb(ep->pkpool);
+  LCII_packet_t* packet = LCII_alloc_packet_nb(ep->pkpool);
   if (packet == NULL) {
     // no packet is available
     LCII_PCOUNTERS_WRAPPER(
@@ -245,7 +245,7 @@ LCI_error_t LCI_putva(LCI_endpoint_t ep, LCI_iovec_t iovec,
         LCII_pcounters[LCIU_get_thread_id()].send_lci_failed_bq++);
     return LCI_ERR_RETRY;
   }
-  LCII_packet_t* packet = LCII_pool_get_nb(ep->pkpool);
+  LCII_packet_t* packet = LCII_alloc_packet_nb(ep->pkpool);
   if (packet == NULL) {
     // no packet is available
     LCII_PCOUNTERS_WRAPPER(

--- a/src/runtime/2sided_primitive.c
+++ b/src/runtime/2sided_primitive.c
@@ -35,7 +35,7 @@ LCI_error_t LCI_sendm(LCI_endpoint_t ep, LCI_mbuffer_t buffer, int rank,
                           buffer.address, buffer.length,
                           LCII_MAKE_PROTO(ep->gid, LCI_MSG_MEDIUM, tag));
   } else {
-    LCII_packet_t* packet = LCII_pool_get_nb(ep->pkpool);
+    LCII_packet_t* packet = LCII_alloc_packet_nb(ep->pkpool);
     if (packet == NULL) {
       // no packet is available
       LCII_PCOUNTERS_WRAPPER(
@@ -118,7 +118,7 @@ LCI_error_t LCI_sendl(LCI_endpoint_t ep, LCI_lbuffer_t buffer, int rank,
         LCII_pcounters[LCIU_get_thread_id()].send_lci_failed_bq++);
     return LCI_ERR_RETRY;
   }
-  LCII_packet_t* packet = LCII_pool_get_nb(ep->pkpool);
+  LCII_packet_t* packet = LCII_alloc_packet_nb(ep->pkpool);
   if (packet == NULL) {
     // no packet is available
     LCII_PCOUNTERS_WRAPPER(

--- a/src/runtime/device.c
+++ b/src/runtime/device.c
@@ -37,12 +37,15 @@ LCI_error_t LCI_device_init(LCI_device_t* device_ptr)
 
   LCII_pool_create(&device->pkpool);
   for (size_t i = 0; i < LCI_SERVER_NUM_PKTS; i++) {
-    LCII_packet_t* p = (LCII_packet_t*)(base_packet + i * LCI_PACKET_SIZE);
-    LCM_Assert(((uint64_t) & (p->data)) % LCI_CACHE_LINE == 0,
+    LCII_packet_t* packet = (LCII_packet_t*)(base_packet + i * LCI_PACKET_SIZE);
+    LCM_Assert(((uint64_t) & (packet->data)) % LCI_CACHE_LINE == 0,
                "packet.data is not well-aligned\n");
-    p->context.pkpool = device->pkpool;
-    p->context.poolid = 0;
-    LCII_pool_put(device->pkpool, p);
+    packet->context.pkpool = device->pkpool;
+    packet->context.poolid = 0;
+#ifdef LCI_DEBUG
+    packet->context.isInPool = true;
+#endif
+    LCII_pool_put(device->pkpool, packet);
   }
   device->did_work_consecutive = 0;
   LCM_Log(LCM_LOG_INFO, "device", "device %p initialized\n", device);

--- a/src/runtime/memory_registration.c
+++ b/src/runtime/memory_registration.c
@@ -29,7 +29,7 @@ LCI_error_t LCI_memory_deregister(LCI_segment_t* segment)
 
 LCI_error_t LCI_mbuffer_alloc(LCI_device_t device, LCI_mbuffer_t* mbuffer)
 {
-  LCII_packet_t* packet = LCII_pool_get_nb(device->pkpool);
+  LCII_packet_t* packet = LCII_alloc_packet_nb(device->pkpool);
   if (packet == NULL)
     // no packet is available
     return LCI_ERR_RETRY;

--- a/src/runtime/progress.c
+++ b/src/runtime/progress.c
@@ -88,7 +88,7 @@ LCI_error_t LCII_fill_rq(LCII_endpoint_t* endpoint)
   // Make sure we always have enough packet, but do not block.
   int ret = LCI_ERR_RETRY;
   while (endpoint->recv_posted < LCI_SERVER_MAX_RECVS) {
-    LCII_packet_t* packet = LCII_pool_get_nb(endpoint->device->pkpool);
+    LCII_packet_t* packet = LCII_alloc_packet_nb(endpoint->device->pkpool);
     if (packet == NULL) {
       LCII_PCOUNTERS_WRAPPER(
           LCII_pcounters[LCIU_get_thread_id()].recv_backend_no_packet++);


### PR DESCRIPTION
This commit add a new field isInPool to the packet context when LCI_DEBUG is enable. It will use this field to check whether the packet has been double freed.