### PR TITLE
Greatly improve matching table search algorithm.

### DIFF
--- a/src/profile/performance_counter.c
+++ b/src/profile/performance_counter.c
@@ -46,6 +46,9 @@ LCII_pcounters_per_thread_t LCII_pcounters_accumulate()
     LCII_PCOUNTERS_FIELD_ADD(backlog_queue_total_count);
     LCII_PCOUNTERS_FIELD_ADD(backlog_queue_send_attempts);
     LCII_PCOUNTERS_FIELD_MAX(backlog_queue_max_len);
+    LCII_PCOUNTERS_FIELD_ADD(hashtable_insert_num);
+    LCII_PCOUNTERS_FIELD_ADD(hashtable_walk_steps_total);
+    LCII_PCOUNTERS_FIELD_MAX(hashtable_walk_steps_max);
     LCII_PCOUNTERS_FIELD_AVE(send_eager_latency_nsec_ave,
                              send_eager_latency_nsec_count);
     LCII_PCOUNTERS_FIELD_AVE(send_iovec_handshake_nsec_ave,
@@ -95,6 +98,9 @@ LCII_pcounters_per_thread_t LCII_pcounters_diff(LCII_pcounters_per_thread_t c1,
     LCII_PCOUNTERS_FIELD_DIFF(backlog_queue_total_count);
     LCII_PCOUNTERS_FIELD_DIFF(backlog_queue_send_attempts);
     LCII_PCOUNTERS_FIELD_KEEP(backlog_queue_max_len);
+    LCII_PCOUNTERS_FIELD_DIFF(hashtable_insert_num);
+    LCII_PCOUNTERS_FIELD_DIFF(hashtable_walk_steps_total);
+    LCII_PCOUNTERS_FIELD_KEEP(hashtable_walk_steps_max);
     LCII_PCOUNTERS_FIELD_KEEP(send_eager_latency_nsec_ave);
     LCII_PCOUNTERS_FIELD_DIFF(send_eager_latency_nsec_count);
     LCII_PCOUNTERS_FIELD_KEEP(send_iovec_handshake_nsec_ave);
@@ -167,6 +173,12 @@ char* LCII_pcounters_to_string(LCII_pcounters_per_thread_t pcounter)
                                  "Backlog queue maximum length");
   LCII_PCOUNTERS_FIELD_TO_STRING(backlog_queue_send_attempts,
                                  "Backlog queue send attempts");
+  LCII_PCOUNTERS_FIELD_TO_STRING(hashtable_insert_num,
+                                 "Matching table insert operation number");
+  LCII_PCOUNTERS_FIELD_TO_STRING(hashtable_walk_steps_total,
+                                 "Matching table total walking step count");
+  LCII_PCOUNTERS_FIELD_TO_STRING(hashtable_walk_steps_max,
+                                 "Matching table maximum walking step count");
   LCII_PCOUNTERS_FIELD_TO_STRING(send_eager_latency_nsec_ave,
                                  "Send eager time average");
   LCII_PCOUNTERS_FIELD_TO_STRING(send_eager_latency_nsec_count,

--- a/src/profile/performance_counter.h
+++ b/src/profile/performance_counter.h
@@ -38,18 +38,22 @@ typedef struct {
   int64_t backlog_queue_total_count;
   int64_t backlog_queue_send_attempts;
   int64_t backlog_queue_max_len;
-  int64_t send_eager_latency_nsec_ave;      // post send -> send comp
-  int64_t send_eager_latency_nsec_count;    // post send -> send comp
-  int64_t send_iovec_handshake_nsec_ave;    // send rts -> recv rtr
-  int64_t send_iovec_handshake_nsec_count;  // send rts -> recv rtr
-  int64_t send_iovec_latency_nsec_ave;      // send rts -> send fin
+  int64_t hashtable_insert_num;
+  int64_t hashtable_walk_steps_total;
+  int64_t hashtable_walk_steps_max;
+  int64_t send_eager_latency_nsec_ave;    // post send -> send comp
+  int64_t send_eager_latency_nsec_count;  // post send -> send comp
   // 8x8 bytes
+  int64_t send_iovec_handshake_nsec_ave;     // send rts -> recv rtr
+  int64_t send_iovec_handshake_nsec_count;   // send rts -> recv rtr
+  int64_t send_iovec_latency_nsec_ave;       // send rts -> send fin
   int64_t send_iovec_latency_nsec_count;     // send rts -> send fin
   int64_t recv_iovec_handle_rts_nsec_ave;    // recv rts -> send rtr
   int64_t recv_iovec_handle_rts_nsec_count;  // recv rts -> send rtr
   int64_t recv_iovec_latency_nsec_ave;       // recv rts -> recv fin
   int64_t recv_iovec_latency_nsec_count;     // recv rts -> recv fin
-  LCIU_CACHE_PADDING(8 * 37);
+  // 8x8 bytes
+  LCIU_CACHE_PADDING(8 * 40);
 } LCII_pcounters_per_thread_t;
 
 #define LCI_PCOUNTER_MAX_NTHREADS 256


### PR DESCRIPTION
I don't quite understand why we need to push the empty entry further when there are non-empty entries. It appears the code wants to guarantee some sort of in-order receives but (1) the specification does not require in-order receives (2) the approach is very slow.

This PR disables the "push the empty entry further" behavior and brings great speedup. It also adds three new performance counters to monitor the matching table behavior.

Experiment: OctoTiger on Expanse, 32 nodes, max_level=4, sendrecv protocol, prepost 8 receives.

Before the change:
```
Running time: ~44s
0,Matching table insert operation number,61832
0,Matching table total walking step count,704968719
0,Matching table maximum walking step count,26556
```
After the change:
```
Running time: ~11s
0,Matching table insert operation number,61826
0,Matching table total walking step count,257058
0,Matching table maximum walking step count,9
```