### PR TITLE
Set the default value of LCI_USE_AVX to be OFF.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,10 +86,9 @@ if(LCI_OPTIMIZE_FOR_NATIVE)
   endif()
 endif()
 
-check_c_compiler_flag("-mavx" COMPILER_SUPPORTS_MAVX)
-option(LCI_USE_AVX "Use GCC vector extension for the immediate field"
-       ${COMPILER_SUPPORTS_MAVX})
+option(LCI_USE_AVX "Use GCC vector extension for the immediate field" OFF)
 if(LCI_USE_AVX)
+  check_c_compiler_flag("-mavx" COMPILER_SUPPORTS_MAVX)
   if(NOT COMPILER_SUPPORTS_MAVX)
     message(
       FATAL_ERROR


### PR DESCRIPTION
Until we figure out why the value of `LCI_short_t` can be passed incorrectly on some systems (at least my laptop) when linking to the installed version of LCI. If we directly write the tests in the LCI repo (such as `examples/puts_handler.c`), it works correctly.

The performance optimization of using avx type for `LCI_short_t` is marginal anyway. 

Thank Weixuan @weixuanzh for finding the bug.