### PR TITLE
Update the spack package file for cray platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,8 +31,12 @@
 .idea
 cmake-build-*
 
+# Spack related
+spack-*
+
 results
 errors
 *_test
 build-*/
 code_doc/
+__pycache__

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,7 @@ if(NOT LCI_WITH_LCT_ONLY)
     "Use the C version of the completion queue so that it could be compiled inline."
     OFF)
   option(LCI_ENABLE_MULTITHREAD_PROGRESS
-         "LCI_progress can be called by multiple threads simultaneously" OFF)
+         "LCI_progress can be called by multiple threads simultaneously" ON)
   option(LCI_OFI_ENABLE_TRY_LOCK_EP
          "Try to lock the OFI endpoint before access it." ON)
   option(LCI_CONFIG_USE_ALIGNED_ALLOC "Enable memory alignment" ON)

--- a/cmake_modules/AddLCI.cmake
+++ b/cmake_modules/AddLCI.cmake
@@ -15,6 +15,8 @@ function(add_lci_executable name)
     PROPERTIES C_STANDARD 99
                C_EXTENSIONS ON
                CXX_STANDARD 11)
+  set_target_properties(${name} PROPERTIES OUTPUT_NAME "lci_${name}")
+  install(TARGETS ${name} RUNTIME)
 endfunction()
 
 function(add_lci_test name)


### PR DESCRIPTION
In addition,
- Update the cmake files to let it install all LCI example/test/benchmark binary by default (with `lci_` prefix) 
- Change the `LCI_ENABLE_MULTITHREAD_PROGRESS` option default value to `ON` as it does not add noticeable overhead and reduces the chance of human error.