### PR TITLE
Add new 2sided primitive, sendmc: send medium messages with completion objects

### DIFF
--- a/lci/api/lci.h
+++ b/lci/api/lci.h
@@ -796,6 +796,26 @@ LCI_error_t LCI_sends(LCI_endpoint_t ep, LCI_short_t src, int rank,
 /**
  * @ingroup LCI_COMM
  * @brief Send a medium message with a user-provided buffer (up to
+ * LCI_MEDIUM_SIZE bytes). The send buffer can be reused after completion
+ * notification.
+ * @param [in] ep     The endpoint to post this send to.
+ * @param [in] buffer The buffer to send.
+ * @param [in] rank   The rank of the destination process.
+ * @param [in] tag    The tag of this message.
+ * @param [in] completion   The completion object to be associated with.
+ * @param [in] user_context Arbitrary data the user want to attach to this
+ * operation. It will be returned the user through the completion object.
+ * @return LCI_OK if the send succeeds. LCI_ERR_RETRY if the send fails due to
+ * temporarily unavailable resources. All the other errors are fatal as defined
+ * by @ref LCI_error_t.
+ */
+LCI_API
+LCI_error_t LCI_sendmc(LCI_endpoint_t ep, LCI_mbuffer_t buffer, int rank,
+                       LCI_tag_t tag, LCI_comp_t completion,
+                       void* user_context);
+/**
+ * @ingroup LCI_COMM
+ * @brief Send a medium message with a user-provided buffer (up to
  * LCI_MEDIUM_SIZE bytes). The send buffer can be immediately reused.
  * @param [in] ep     The endpoint to post this send to.
  * @param [in] buffer The buffer to send.

--- a/lci/experimental/coll/coll.h
+++ b/lci/experimental/coll/coll.h
@@ -144,7 +144,7 @@ static inline void LCIXC_mcoll_complete(LCI_endpoint_t ep, LCI_mbuffer_t buffer,
   LCII_comp_attr_set_comp_type(ctx->comp_attr, ep->msg_comp_type);
   ctx->data_type = LCI_MEDIUM;
   ctx->user_context = user_context;
-  ctx->data = (LCI_data_t){.mbuffer = buffer};
+  ctx->data.mbuffer = buffer;
   ctx->rank = -1; /* this doesn't make much sense for collectives */
   ctx->tag = tag;
   ctx->completion = completion;
@@ -160,7 +160,7 @@ static inline void LCIXC_lcoll_complete(LCI_endpoint_t ep, LCI_lbuffer_t buffer,
   LCII_comp_attr_set_comp_type(ctx->comp_attr, ep->msg_comp_type);
   ctx->data_type = LCI_LONG;
   ctx->user_context = user_context;
-  ctx->data = (LCI_data_t){.lbuffer = buffer};
+  ctx->data.lbuffer = buffer;
   ctx->rank = -1; /* this doesn't make much sense for collectives */
   ctx->tag = tag;
   ctx->completion = completion;

--- a/lci/runtime/1sided_primitive.c
+++ b/lci/runtime/1sided_primitive.c
@@ -66,7 +66,7 @@ LCI_error_t LCI_putma(LCI_endpoint_t ep, LCI_mbuffer_t buffer, int rank,
     memcpy(packet->data.address, buffer.address, buffer.length);
 
     LCII_context_t* ctx = LCIU_malloc(sizeof(LCII_context_t));
-    ctx->data.mbuffer.address = (void*)packet->data.address;
+    ctx->data.packet = packet;
     LCII_initilize_comp_attr(ctx->comp_attr);
     LCII_comp_attr_set_free_packet(ctx->comp_attr, 1);
 
@@ -108,7 +108,7 @@ LCI_error_t LCI_putmna(LCI_endpoint_t ep, LCI_mbuffer_t buffer, int rank,
                                : -1;
 
   LCII_context_t* ctx = LCIU_malloc(sizeof(LCII_context_t));
-  ctx->data.mbuffer.address = (void*)packet->data.address;
+  ctx->data.packet = packet;
   LCII_initilize_comp_attr(ctx->comp_attr);
   LCII_comp_attr_set_free_packet(ctx->comp_attr, 1);
 
@@ -158,7 +158,7 @@ LCI_error_t LCI_putla(LCI_endpoint_t ep, LCI_lbuffer_t buffer,
   packet->context.poolid = LCII_POOLID_LOCAL;
 
   LCII_context_t* rts_ctx = LCIU_malloc(sizeof(LCII_context_t));
-  rts_ctx->data.mbuffer.address = (void*)packet->data.address;
+  rts_ctx->data.packet = packet;
   LCII_initilize_comp_attr(rts_ctx->comp_attr);
   LCII_comp_attr_set_free_packet(rts_ctx->comp_attr, 1);
 
@@ -245,7 +245,7 @@ LCI_error_t LCI_putva(LCI_endpoint_t ep, LCI_iovec_t iovec,
           : -1;
 
   LCII_context_t* rts_ctx = LCIU_malloc(sizeof(LCII_context_t));
-  rts_ctx->data.mbuffer.address = (void*)packet->data.address;
+  rts_ctx->data.packet = packet;
   LCII_initilize_comp_attr(rts_ctx->comp_attr);
   LCII_comp_attr_set_free_packet(rts_ctx->comp_attr, 1);
 

--- a/lci/runtime/completion/sync_flag.c
+++ b/lci/runtime/completion/sync_flag.c
@@ -57,9 +57,8 @@ LCI_error_t LCI_sync_signal(LCI_comp_t completion, LCI_request_t request)
   ctx->rank = request.rank;
   ctx->tag = request.tag;
   ctx->data_type = request.type;
-  ctx->data = request.data;
+  memcpy(&ctx->data, &request.data, sizeof(ctx->data));
   ctx->user_context = request.user_context;
-
   LCII_sync_signal(completion, ctx);
   return LCI_OK;
 }

--- a/lci/runtime/lci.c
+++ b/lci/runtime/lci.c
@@ -118,12 +118,15 @@ LCI_error_t LCII_barrier()
     while (LCI_sync_test(sync, NULL) != LCI_OK) {
       LCI_progress(LCI_UR_DEVICE);
     }
-    LCI_sync_free(&sync);
     // Phase 2: rank 0 send a message to all the other ranks.
     for (int i = 1; i < LCI_NUM_PROCESSES; ++i) {
-      while (LCI_sendm(ep, buffer, i, tag) != LCI_OK)
+      while (LCI_sendmc(ep, buffer, i, tag, sync, NULL) != LCI_OK)
         LCI_progress(LCI_UR_DEVICE);
     }
+    while (LCI_sync_test(sync, NULL) != LCI_OK) {
+      LCI_progress(LCI_UR_DEVICE);
+    }
+    LCI_sync_free(&sync);
   }
   LCI_Log(LCI_LOG_INFO, "coll", "End barrier (%d, %p).\n", tag, ep);
   return LCI_OK;

--- a/lci/runtime/memory_registration.c
+++ b/lci/runtime/memory_registration.c
@@ -41,6 +41,7 @@ LCI_error_t LCI_mbuffer_alloc(LCI_device_t device, LCI_mbuffer_t* mbuffer)
 
   mbuffer->address = packet->data.address;
   mbuffer->length = LCI_MEDIUM_SIZE;
+  LCI_DBG_Assert(LCII_is_packet(device, mbuffer->address), "");
   return LCI_OK;
 }
 

--- a/lci/runtime/packet.h
+++ b/lci/runtime/packet.h
@@ -102,4 +102,14 @@ static inline LCII_packet_t* LCII_mbuffer2packet(LCI_mbuffer_t mbuffer)
   return (LCII_packet_t*)(mbuffer.address - offsetof(LCII_packet_t, data));
 }
 
+static inline bool LCII_is_packet(LCI_device_t device, void* address)
+{
+  void* packet_address =
+      (LCII_packet_t*)(address - offsetof(LCII_packet_t, data));
+  uintptr_t offset = (uintptr_t)packet_address - device->base_packet;
+  return (uintptr_t)packet_address >= device->base_packet &&
+         offset % LCI_PACKET_SIZE == 0 &&
+         offset / LCI_PACKET_SIZE < LCI_SERVER_NUM_PKTS;
+}
+
 #endif

--- a/lci/runtime/protocol.h
+++ b/lci/runtime/protocol.h
@@ -202,7 +202,7 @@ static inline void LCIS_serve_send(void* raw_ctx)
     return;
   }
   if (LCII_comp_attr_get_free_packet(ctx->comp_attr) == 1) {
-    LCII_free_packet(LCII_mbuffer2packet(ctx->data.mbuffer));
+    LCII_free_packet(ctx->data.packet);
   }
   lc_ce_dispatch(ctx);
 }

--- a/lci/runtime/rendezvous.h
+++ b/lci/runtime/rendezvous.h
@@ -238,7 +238,7 @@ static inline void LCII_handle_rts(LCI_endpoint_t ep, LCII_packet_t* packet,
 
   // Prepare the RTR context
   LCII_context_t* rtr_ctx = LCIU_malloc(sizeof(LCII_context_t));
-  rtr_ctx->data.mbuffer.address = &(packet->data);
+  rtr_ctx->data.packet = packet;
   LCII_initilize_comp_attr(rtr_ctx->comp_attr);
   LCII_comp_attr_set_free_packet(rtr_ctx->comp_attr, 1);
 


### PR DESCRIPTION
I need "case 2" completion (the send is completed when no more `LCI_progress` is needed) in the LCI_barrier implementation. Otherwise, LCI will hang at the very end when running on Delta SS-11. 

`sendmc` is a temporary solution before #63 is discussed. It appears that it has fixed the hanging issue on Delta.

flyby: I also changed the OFI write to `FI_DELIVERY_COMPLETION` to make sure the FIN message is received after the data has been written to the receiver's memory.