### PR TITLE
Refactor performance counters: "on-the-fly" and "on-the-fly-lw" modes

### DIFF
--- a/contrib/spack/packages/lci/package.py
+++ b/contrib/spack/packages/lci/package.py
@@ -68,7 +68,7 @@ class Lci(CMakePackage):
             description='Default: Max posted cqes')
 
     variant('debug', default=False, description='Enable debug mode')
-    variant('debug-perfcounter', default=False,
+    variant('pcounter', default=False,
             description='Use performance counter')
     variant('debug-slow', default=False, description='Enable manual slowdown')
     variant('papi', default=False,
@@ -105,7 +105,7 @@ class Lci(CMakePackage):
             self.define('LCI_USE_DREG_DEFAULT',
                         1 if self.spec.variants['default-dreg'].value else 0),
             self.define_from_variant('LCI_DEBUG', 'debug'),
-            self.define_from_variant('LCI_USE_PERFORMANCE_COUNTER', 'debug-perfcounter'),
+            self.define_from_variant('LCI_USE_PERFORMANCE_COUNTER', 'pcounter'),
             self.define_from_variant('LCI_ENABLE_SLOWDOWN', 'debug-slow'),
             self.define_from_variant('LCI_USE_PAPI', 'papi'),
             self.define_from_variant('LCI_USE_GPROF', 'gprof'),

--- a/lci/backend/server.h
+++ b/lci/backend/server.h
@@ -152,7 +152,7 @@ static inline LCI_error_t LCIS_post_sends(LCIS_endpoint_t endpoint_pp, int rank,
 #endif
   LCI_error_t ret = LCISD_post_sends(endpoint_pp, rank, buf, size, meta);
   if (ret == LCI_OK) {
-    LCII_PCOUNTER_ADD(net_send_posted, (int64_t)size);
+    LCII_PCOUNTER_ADD(net_sends_posted, (int64_t)size);
   } else if (ret == LCI_ERR_RETRY_LOCK) {
     LCII_PCOUNTER_ADD(net_send_failed_lock, 1);
     ret = LCI_ERR_RETRY;
@@ -199,7 +199,7 @@ static inline LCI_error_t LCIS_post_puts(LCIS_endpoint_t endpoint_pp, int rank,
   LCI_error_t ret =
       LCISD_post_puts(endpoint_pp, rank, buf, size, base, offset, rkey);
   if (ret == LCI_OK) {
-    LCII_PCOUNTER_ADD(net_send_posted, (int64_t)size);
+    LCII_PCOUNTER_ADD(net_sends_posted, (int64_t)size);
   } else if (ret == LCI_ERR_RETRY_LOCK) {
     LCII_PCOUNTER_ADD(net_send_failed_lock, 1);
     ret = LCI_ERR_RETRY;

--- a/lci/profile/performance_counter.h
+++ b/lci/profile/performance_counter.h
@@ -21,6 +21,7 @@ extern LCT_pcounter_ctx_t LCII_pcounter_ctx;
     _macro(recv)                             \
     _macro(comp_produce)                     \
     _macro(comp_consume)                     \
+    _macro(net_sends_posted)                 \
     _macro(net_send_posted)                  \
     _macro(net_recv_posted)                  \
     _macro(net_send_comp)                    \


### PR DESCRIPTION
Rename the previous "on-the-fly" mode into "on-the-fly-lw": in this mode, a monitor thread will tell application threads "it's time to dump the performance counters". It is the application threads' job to dump the performance counters. It is called "lightweight" because no performance counters will be dumped if they are not changed.

In the new "on-the-fly" mode, a monitor thread will directly dump the performance counters at fixed intervals. It is useful for debugging deadlocks.