### PR TITLE
coll/barrier: fix op undercount and buffer overflow for non-power-of-two

### DIFF
--- a/lci/experimental/coll/barrier.c
+++ b/lci/experimental/coll/barrier.c
@@ -20,8 +20,8 @@ LCI_error_t LCIX_barrier(LCI_endpoint_t ep, LCI_tag_t tag,
     return LCI_OK;
   }
 
-  /* We have at most 2 * ilog2(size) scheduled operations */
-  sched_ops = 2 * ilog2(size);
+  /* We have at most 2 * (1 + ilog2(size)) scheduled operations */
+  sched_ops = 2 * (1 + ilog2(size));
 
   LCIX_collective_t coll = LCIU_malloc(sizeof(struct LCIX_collective_s));
   LCIXC_mcoll_init(coll, ep, tag, NULL, completion, user_context, empty,


### PR DESCRIPTION
For non-power-of-two node counts, the barrier code would undercount the number of required iterations by one and, therefore, the number of scheduled operations by two. This would result in underallocating the buffer for scheduled operations and, subsequently, a buffer overflow, which would trash memory used internally by malloc and cause a crash.

Fix this by counting correctly. This overcounts (and overallocates) the scheduled operations for power-of-two node counts, but this is harmless, other than allocating an additional 80 bytes.