### PR TITLE
fix lcit initData: affect lcitb's performance

### DIFF
--- a/benchmarks/lcitb_pt2pt.cpp
+++ b/benchmarks/lcitb_pt2pt.cpp
@@ -6,6 +6,7 @@ using namespace lcit;
 
 void test(Context ctx)
 {
+  Data data = initData(ctx);
   int tag = 245 + TRD_RANK_ME;
   //  int peer_rank = ((1 - LCI_RANK % 2) + LCI_RANK / 2 * 2) %
   //  LCI_NUM_PROCESSES; // 0 <-> 1, 2 <-> 3
@@ -21,20 +22,20 @@ void test(Context ctx)
         std::vector<LCI_comp_t> comps;
         // send
         for (int j = 0; j < ctx.config.send_window; ++j) {
-          LCI_comp_t comp = postSend(ctx, peer_rank, size, tag);
+          LCI_comp_t comp = postSend(ctx, peer_rank, data, size, tag);
           comps.push_back(comp);
         }
         for (auto comp : comps) {
-          waitSend(ctx, comp);
+          waitSend(ctx, data, comp);
         }
         // recv
         comps.clear();
         for (int j = 0; j < ctx.config.recv_window; ++j) {
-          LCI_comp_t comp = postRecv(ctx, peer_rank, size, tag);
+          LCI_comp_t comp = postRecv(ctx, peer_rank, data, size, tag);
           comps.push_back(comp);
         }
         for (auto comp : comps) {
-          waitRecv(ctx, comp);
+          waitRecv(ctx, data, comp);
         }
       });
       if (TRD_RANK_ME == 0 && LCI_RANK == 0) {
@@ -56,24 +57,25 @@ void test(Context ctx)
         std::vector<LCI_comp_t> comps;
         // recv
         for (int j = 0; j < ctx.config.send_window; ++j) {
-          LCI_comp_t comp = postRecv(ctx, peer_rank, size, tag);
+          LCI_comp_t comp = postRecv(ctx, peer_rank, data, size, tag);
           comps.push_back(comp);
         }
         for (auto comp : comps) {
-          waitRecv(ctx, comp);
+          waitRecv(ctx, data, comp);
         }
         // send
         comps.clear();
         for (int j = 0; j < ctx.config.recv_window; ++j) {
-          LCI_comp_t comp = postSend(ctx, peer_rank, size, tag);
+          LCI_comp_t comp = postSend(ctx, peer_rank, data, size, tag);
           comps.push_back(comp);
         }
         for (auto comp : comps) {
-          waitSend(ctx, comp);
+          waitSend(ctx, data, comp);
         }
       });
     }
   }
+  freeData(ctx, data);
 }
 
 int main(int argc, char** args)

--- a/lci/backend/ofi/server_ofi.h
+++ b/lci/backend/ofi/server_ofi.h
@@ -12,16 +12,16 @@
 #include <rdma/fi_errno.h>
 #include <rdma/fi_rma.h>
 
-#define FI_SAFECALL(x)                                                        \
-  {                                                                           \
-    int err = (x);                                                            \
-    if (err < 0) err = -err;                                                  \
-    if (err) {                                                                \
-      LCI_DBG_Assert(false, "err : %s (%s:%d)\n", fi_strerror(err), __FILE__, \
-                     __LINE__);                                               \
-    }                                                                         \
-  }                                                                           \
-  while (0)                                                                   \
+#define FI_SAFECALL(x)                                                    \
+  {                                                                       \
+    int err = (x);                                                        \
+    if (err < 0) err = -err;                                              \
+    if (err) {                                                            \
+      LCI_Assert(false, "err : %s (%s:%d)\n", fi_strerror(err), __FILE__, \
+                 __LINE__);                                               \
+    }                                                                     \
+  }                                                                       \
+  while (0)                                                               \
     ;
 
 #define LCISI_OFI_CS_TRY_ENTER(endpoint_p, mode, ret)                        \

--- a/tests/lcit/lcit_many2one.cpp
+++ b/tests/lcit/lcit_many2one.cpp
@@ -5,6 +5,7 @@ using namespace lcit;
 
 void test(Context ctx)
 {
+  Data data = initData(ctx);
   int rank = LCI_RANK;
   int tag = 245 + TRD_RANK_ME;
 
@@ -21,12 +22,12 @@ void test(Context ctx)
         for (int j = 0; j < ctx.config.recv_window; ++j) {
           for (int target_rank = 1; target_rank < LCI_NUM_PROCESSES;
                ++target_rank) {
-            LCI_comp_t comp = postRecv(ctx, target_rank, size, tag);
+            LCI_comp_t comp = postRecv(ctx, target_rank, data, size, tag);
             comps.push_back(comp);
           }
         }
         for (auto comp : comps) {
-          waitRecv(ctx, comp);
+          waitRecv(ctx, data, comp);
         }
         // send
         threadBarrier(ctx);
@@ -34,12 +35,12 @@ void test(Context ctx)
         for (int j = 0; j < ctx.config.send_window; ++j) {
           for (int target_rank = 1; target_rank < LCI_NUM_PROCESSES;
                ++target_rank) {
-            LCI_comp_t comp = postSend(ctx, target_rank, size, tag);
+            LCI_comp_t comp = postSend(ctx, target_rank, data, size, tag);
             comps.push_back(comp);
           }
         }
         for (auto comp : comps) {
-          waitSend(ctx, comp);
+          waitSend(ctx, data, comp);
         }
       }
     }
@@ -51,25 +52,26 @@ void test(Context ctx)
         // send
         threadBarrier(ctx);
         for (int j = 0; j < ctx.config.recv_window; ++j) {
-          LCI_comp_t comp = postSend(ctx, 0, size, tag);
+          LCI_comp_t comp = postSend(ctx, 0, data, size, tag);
           comps.push_back(comp);
         }
         for (auto comp : comps) {
-          waitSend(ctx, comp);
+          waitSend(ctx, data, comp);
         }
         // recv
         threadBarrier(ctx);
         comps.clear();
         for (int j = 0; j < ctx.config.send_window; ++j) {
-          LCI_comp_t comp = postRecv(ctx, 0, size, tag);
+          LCI_comp_t comp = postRecv(ctx, 0, data, size, tag);
           comps.push_back(comp);
         }
         for (auto comp : comps) {
-          waitRecv(ctx, comp);
+          waitRecv(ctx, data, comp);
         }
       }
     }
   }
+  freeData(ctx, data);
 }
 
 int main(int argc, char** args)

--- a/tests/lcit/lcit_pt2pt.cpp
+++ b/tests/lcit/lcit_pt2pt.cpp
@@ -5,6 +5,7 @@ using namespace lcit;
 
 void test(Context ctx)
 {
+  Data data = initData(ctx);
   int rank = LCI_RANK;
   int tag = 245 + TRD_RANK_ME;
   int peer_rank = ((1 - LCI_RANK % 2) + LCI_RANK / 2 * 2) % LCI_NUM_PROCESSES;
@@ -20,20 +21,20 @@ void test(Context ctx)
         std::vector<LCI_comp_t> comps;
         // send
         for (int j = 0; j < ctx.config.send_window; ++j) {
-          LCI_comp_t comp = postSend(ctx, peer_rank, size, tag);
+          LCI_comp_t comp = postSend(ctx, peer_rank, data, size, tag);
           comps.push_back(comp);
         }
         for (auto comp : comps) {
-          waitSend(ctx, comp);
+          waitSend(ctx, data, comp);
         }
         // recv
         comps.clear();
         for (int j = 0; j < ctx.config.recv_window; ++j) {
-          LCI_comp_t comp = postRecv(ctx, peer_rank, size, tag);
+          LCI_comp_t comp = postRecv(ctx, peer_rank, data, size, tag);
           comps.push_back(comp);
         }
         for (auto comp : comps) {
-          waitRecv(ctx, comp);
+          waitRecv(ctx, data, comp);
         }
       }
     }
@@ -45,24 +46,25 @@ void test(Context ctx)
         std::vector<LCI_comp_t> comps;
         // recv
         for (int j = 0; j < ctx.config.send_window; ++j) {
-          LCI_comp_t comp = postRecv(ctx, peer_rank, size, tag);
+          LCI_comp_t comp = postRecv(ctx, peer_rank, data, size, tag);
           comps.push_back(comp);
         }
         for (auto comp : comps) {
-          waitRecv(ctx, comp);
+          waitRecv(ctx, data, comp);
         }
         // send
         comps.clear();
         for (int j = 0; j < ctx.config.recv_window; ++j) {
-          LCI_comp_t comp = postSend(ctx, peer_rank, size, tag);
+          LCI_comp_t comp = postSend(ctx, peer_rank, data, size, tag);
           comps.push_back(comp);
         }
         for (auto comp : comps) {
-          waitSend(ctx, comp);
+          waitSend(ctx, data, comp);
         }
       }
     }
   }
+  freeData(ctx, data);
 }
 
 int main(int argc, char** args)


### PR DESCRIPTION
The original `lcit` implementation calls `initData` (allocates the send/recv buffers) in `initCtx` (usually called at the main thread). This leads to suboptimal performance when the program scales to multiple NUMA nodes. This PR fixes it by calling `initData` in each thread.